### PR TITLE
Fix: exact domain match did not work properly

### DIFF
--- a/src/__tests__/suggest.test.ts
+++ b/src/__tests__/suggest.test.ts
@@ -42,3 +42,7 @@ test("Override domains", () => {
 test("Override domain with old domain", () => {
   expect(suggestWithOptions("test@gnail.com")).toBe(undefined);
 });
+
+test("Exact domain matched", () => {
+  expect(suggest("test@mail.numerique.org", { domains: ["mail.numerique.org", "gmail.com"] })).toBe(undefined);
+});

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -24,7 +24,8 @@ const findClosestDomain = (domain: string, domains: string[], threshold: number)
   if (!domain || !domains) {
     return;
   }
-  domains.forEach(currentDomain => {
+  for (let i = 0; i < domains.length; i++) {
+    const currentDomain = domains[i];
     if (domain === currentDomain) {
       return domain;
     }
@@ -33,7 +34,7 @@ const findClosestDomain = (domain: string, domains: string[], threshold: number)
       minDist = dist;
       closestDomain = currentDomain;
     }
-  });
+  }
   if (minDist <= (threshold || topLevelThreshold) && closestDomain !== undefined) {
     return closestDomain;
   } else {


### PR DESCRIPTION
This was due to return in `forEach` which did not work as expected